### PR TITLE
RCF-5018 Add `@changelog.disable_sideeffects`

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -17,6 +17,7 @@ const addSideEffects = (actions, flag, element) => {
   }
 
   for (const se of Object.values(actions)) {
+    if (se['@changelog.disable_sideeffects']) continue
     const target = flag ? 'TargetProperties' : 'TargetEntities'
     const sideEffectAttr = se[`@Common.SideEffects.${target}`]
     const property = flag ? 'changes' : { '=': `${element}.changes` }


### PR DESCRIPTION
- Support @changelog.disable_sideeffects on actions

Actions that destroy their bound entity (e.g. draft activation or deletion) cause a 404 when the change-tracking plugin adds `changes` to `@Common.SideEffects.TargetProperties`. The UI tries to reload the change history on an entity that no longer exists.

This adds a check in `addSideEffects` to skip actions annotated with `@changelog.disable_sideeffects: true`, allowing consumers to opt specific actions out of the automatic `changes` side effect as in https://github.tools.sap/RAST/rct/pull/2526